### PR TITLE
correctly pass password to mariadb-dump command

### DIFF
--- a/src/step-mariadb.go
+++ b/src/step-mariadb.go
@@ -60,7 +60,7 @@ func (s *mariadbStep) Run(m *MetricsCollection) (err error) {
 	}
 	defer s.running.Set(false)
 
-	args := []string{"-h", s.host, "-u", s.user, "-p", s.password}
+	args := []string{"-h", s.host, "-u", s.user, "--password=" + s.password}
 	args = append(args, s.database)
 	cmdDb := exec.Command("mariadb-dump", args...)
 


### PR DESCRIPTION
This PR changes the arguments for password from "-p abcd" to "--password=abcd"

According to the documentation at https://mariadb.com/kb/en/mysqldump/ 

> The password to use when connecting to the server. If you use the short option form (-p), you cannot have a space between the option and the password. If you omit the password value following the --password or -p option on the command line, mysqldump prompts for one.

